### PR TITLE
Controls/update tbl

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -723,8 +723,7 @@ void control_config_bind(int i, const CC_bind &new_bind, selItem order)
 			break;
 
 		default:
-			// Ignore and complain
-			mprintf(("Notice: Unknown order (%i) passed to control_config_bind_btn. Ignoring.", static_cast<int>(order)));
+			UNREACHABLE("Notice: Unknown order (%i) passed to control_config_bind_btn. Ignoring.\n", static_cast<int>(order));
 			return;
 	}
 
@@ -1089,8 +1088,7 @@ void control_config_toggle_invert()
 		item.second.invert_toggle();
 		break;
 	default:
-		// unhandled
-		mprintf(("Unhandled selItem in control_config_toggle_invert(): %i", static_cast<int>(Selected_item)));
+		UNREACHABLE("Unhandled selItem in control_config_toggle_invert(): %i\n", static_cast<int>(Selected_item));
 	}
 }
 
@@ -1642,8 +1640,7 @@ int set_item_color(int line, int select_tease_line, selItem item, bool empty) {
 		conflict_id = Conflicts[z].second;
 		break;
 	default:
-		mprintf(("Invalid selItem passed to set_item_color: %i", static_cast<int>(item)));
-		Int3();
+		UNREACHABLE("Invalid selItem passed to set_item_color: %i", static_cast<int>(item));
 	}
 
 	if (conflict_id >= 0) {

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1237,6 +1237,15 @@ int control_config_accept()
 		}
 
 		SCP_string str = cstr;
+		
+		// Check if a hardcoded preset with name already exists. If so, complain to user and force retry
+		auto it = std::find_if(Control_config_presets.begin(), Control_config_presets.end(),
+							  [str](CC_preset& p) { return (p.name == str) && ((p.type == Preset_t::tbl) || (p.type == Preset_t::hardcode)); });
+
+		if (it != Control_config_presets.end()) {
+			popup(flags, 1, POPUP_OK, "You may not overwrite a default preset.  Please choose another name.");
+			goto retry;
+		}
 
 		// Check if a preset file with name already exists.  If so, prompt the user
 		CFILE* fp = cfopen((str + ".json").c_str(), "r", CFILE_NORMAL, CF_TYPE_PLAYER_BINDS, false,

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -320,6 +320,15 @@ enum {
 };
 }
 
+/*!
+ * Where the preset is located in memory
+ */
+enum class Preset_t {
+	hardcode,	// Preset is defined hardcode
+	tbl,		// Preset is defined in controlconfigdefaults.tbl
+	pst			// Preset is defined in a .json
+};
+
 class CCB;
 
 /*!
@@ -507,6 +516,7 @@ class CC_preset {
 public:
 	SCP_vector<CCB> bindings;
 	SCP_string name;
+	Preset_t type;
 };
 
 /*!
@@ -666,6 +676,8 @@ void control_config_use_preset(CC_preset &preset);
  *
  * @returns an iterator to the current preset, or
  * @returns Control_config_presets.end() if current bindings are not in a preset
+ *
+ * @note Similar to preset_find_duplicate, this function has additional logic in its search to ignore disabled controls
  */
 SCP_vector<CC_preset>::iterator control_config_get_current_preset();
 

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -21,6 +21,7 @@
 #define CCF_AXIS        0x08    //!< btn is an axis
 #define CCF_HAT         0x04    //!< btn is a hat
 #define CCF_BALL        0x02    //!< btn is a ball
+#define CCF_BUTTON      0x00    //!< btn is actually a button
 
 /*!
  * These are used to index a corresponding axis value from an array.

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -452,12 +452,12 @@ public:
 	/*!
 	 * Checks if the given CCB is exactly equal to this
 	 */
-	bool operator==(const CCB&);
+	bool operator==(const CCB&) const;
 
 	/*!
 	 * Checks if the given CCB differs from this
 	 */
-	bool operator!=(const CCB&);
+	bool operator!=(const CCB&) const;
 
 	/*!
 	 * Returns True if this CCB's first isn't empty and the given CCB has a binding equal to it

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -807,17 +807,17 @@ CID CIDToVal(const char * str);
 
 /**
  * Reverse lookups the CID to get its stringified name
- * @return  Pointer to the stringified name of the CID, or
- * @return  nullptr if not found
+ * @return  The stringified name of the CID, or
+ * @return  "NONE" if not found
  */
-const char * ValToCID(CID id);
+SCP_string ValToCID(CID id);
 
 /**
  * Reverse lookups the CID to get its stringified name
- * @return Pointer to the stringified name of the CID, or
- * @return nullptr if not found, or invalid id
+ * @return The stringified name of the CID, or
+ * @return "NONE" if not found, or invalid id
  */
-const char * ValToCID(int id);
+SCP_string ValToCID(int id);
 
 /**
  * Lookups the given stringified enum to find its value
@@ -826,8 +826,8 @@ char CCFToVal(const char * str);
 
 /**
  * Constructs a enum string from the CCF_FLAGS
- * @return Pointer to the stringified name of the CCF, or
- * @return nullptr if not found, or invalid id
+ * @return The stringified name of the CCF, or
+ * @return "NONE" if not found, or invalid id
  */
 SCP_string ValToCCF(char id);
 
@@ -839,8 +839,8 @@ short InputToVal(CID cid, const char * str);
 /**
  * Constructs a enumstring from the input binding, depending on the CID
  *
- * @return Pointer to the stringified name of the input, or
- * @return nullptr if not found, or invalid CC_bind
+ * @return The stringified name of the input, or
+ * @return "NONE" if not found, or invalid CC_bind
  *
  * @note This requires a CCB due to the way things are encoded
  */
@@ -854,8 +854,8 @@ short MouseToVal(const char * str);
 /**
  * Constructs a enum string from the mouse input
  *
- * @return Pointer to the stringified name of the input, or
- * @return nullptr if not found, or invalid CC_bind
+ * @return The stringified name of the input, or
+ * @return "NONE" if not found, or invalid CC_bind
  * TODO XSTR
  *
  * @note This requires a CCB due to the way things are encoded
@@ -870,8 +870,8 @@ short KeyboardToVal(const char * str);
 /**
  * Constructs an enum string from the key binding
  *
- * @return Pointer to the stringified name of the input, or
- * @return nullptr if not found, or invalid CC_bind
+ * @return The stringified name of the input, or
+ * @return "NONE" f not found, or invalid CC_bind
  *
  * @note This requires a CCB due to the way things are encoded
  * TODO XSTR
@@ -886,11 +886,38 @@ short JoyToVal(const char * str);
 /**
  * Constructs a enum string from the Joystick input
  *
- * @return Pointer to the stringified name of the input, or
- * @return nullptr if not found, or invalid CC_bind
+ * @return The stringified name of the input, or
+ * @return "NONE" if not found, or invalid CC_bind
  *
  * @note This requires a CCB due to the way things are encoded
  * TODO XSTR
  */
 SCP_string ValToJoy(const CC_bind &bind);
+
+/**
+ * Lookups the given string to find its tab value
+ */
+char CCTabToVal(const char *str);
+
+/**
+ * Reverse lookups the given tab in mCCTabToVal to retrieve the string name
+ *
+ * @return The stringified name of the input, or
+ * @return nullptr if not found, or invalid tab
+ *
+ */
+SCP_string ValToCCTab(char tab);
+
+/**
+ * Lookups the given string to find its CC_type value. =
+ */
+CC_type CCTypeToVal(const char *str);
+
+/**
+ * Reverse lookups the given CC_type to retrieve the string name
+
+ */
+SCP_string ValToCCType(CC_type type);
+
+
 #endif

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -517,6 +517,12 @@ public:
 	SCP_vector<CCB> bindings;
 	SCP_string name;
 	Preset_t type;
+
+public:
+	CC_preset() = default;
+	CC_preset(const CC_preset& A) = default;
+
+	CC_preset& operator=(const CC_preset&);
 };
 
 /*!

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -664,8 +664,8 @@ void control_config_use_preset(CC_preset &preset);
 /**
  * @brief Gets the currently used preset
  *
- * @returns a pointer to the current preset, or
- * @returns nullptr if current bindings are not in a preset
+ * @returns an iterator to the current preset, or
+ * @returns Control_config_presets.end() if current bindings are not in a preset
  */
 SCP_vector<CC_preset>::iterator control_config_get_current_preset();
 

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1478,6 +1478,8 @@ void control_config_common_read_section(int s) {
 			// Gameplay options
 			if (optional_string("+Disable")) {
 				item->disabled = true;
+			} else {
+				item->disabled = false;
 			}
 
 			if (optional_string("$Disable:")) {

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1441,10 +1441,9 @@ void control_config_common_read_section(int s) {
 		if (item_id == Control_config.size()) {
 			// Bind not found.
 			// Try to resume
-			if (!skip_to_start_of_string_either("#End", "$Bind Name:")) {
-				// Couldn't find next binding or end. Fail
-				throw parse::ParseException("Could not find #End or $Bind Name");
-
+			if (!skip_to_start_of_string_either("$Bind Name:", "$Bind", "#End")) {
+				Warning(LOCATION, "Could not find next binding in section %i, canceling read of section.", s);
+				return;
 			} // Found next binding or end, continue loop
 			continue;
 		}

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1442,7 +1442,7 @@ void control_config_common_read_section(int s) {
 			// Bind not found.
 			// Try to resume
 			if (!skip_to_start_of_string_either("$Bind Name:", "$Bind", "#End")) {
-				Warning(LOCATION, "Could not find next binding in section %i, canceling read of section.", s);
+				Warning(LOCATION, "Could not find next binding in section `%s`, canceling read of section.", new_preset.name.c_str());
 				return;
 			} // Found next binding or end, continue loop
 			continue;

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1321,7 +1321,7 @@ size_t read_bind_1(CC_preset &preset) {
 		// Control wasn't found
 		error_display(0, "Unknown Bind: %s\n", szTempBuffer.c_str());
 
-		return item_id;
+		return Control_config.size();
 	}
 	
 	if (optional_string("$Primary:")) {

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1215,7 +1215,7 @@ void stuff_CCF(char& flags, size_t item_id) {
 		// Digital control. May not have:
 		mask = flags & (CCF_AXIS | CCF_BALL);
 		if (mask != 0) {
-			error_display(0, "Illegal analog flags passed to digital config item %i, ignoring:\n'%s'", static_cast<int>(item_id), ValToCCF(mask));
+			error_display(0, "Illegal analog flags passed to digital config item %i, ignoring:\n'%s'", static_cast<int>(item_id), ValToCCF(mask).c_str());
 			flags &= ~(CCF_AXIS | CCF_BALL);
 		}
 		break;
@@ -1224,13 +1224,13 @@ void stuff_CCF(char& flags, size_t item_id) {
 		// Absolute Analog control. Must not have:
 		mask = flags & (CCF_AXIS_BTN | CCF_HAT);
 		if (mask != 0) {
-			error_display(0, "Illegal digital flags passed to analog config item %i, ignoring:\n'%s'", static_cast<int>(item_id), ValToCCF(mask));
+			error_display(0, "Illegal digital flags passed to analog config item %i, ignoring:\n'%s'", static_cast<int>(item_id), ValToCCF(mask).c_str());
 			flags &= ~(CCF_AXIS_BTN | CCF_HAT);
 		}
 
 		mask = flags & CCF_RELATIVE;
 		if (mask != 0) {
-			error_display(0, "Illegal RELATIVE flag passed to absolute analog config item %i, ignoring:\n'%s'", static_cast<int>(item_id), ValToCCF(mask));
+			error_display(0, "Illegal RELATIVE flag passed to absolute analog config item %i, ignoring:\n'%s'", static_cast<int>(item_id), ValToCCF(mask).c_str());
 			flags &= ~CCF_RELATIVE;
 		}
 
@@ -1246,7 +1246,7 @@ void stuff_CCF(char& flags, size_t item_id) {
 		// Relative Analog control. Must not have:
 		mask = flags & (CCF_AXIS_BTN | CCF_HAT);
 		if (mask != 0) {
-			error_display(0, "Illegal digital flags passed to analog config item %i, ignoring:\n'%s'", static_cast<int>(item_id), ValToCCF(mask));
+			error_display(0, "Illegal digital flags passed to analog config item %i, ignoring:\n'%s'", static_cast<int>(item_id), ValToCCF(mask).c_str());
 			flags &= ~(CCF_AXIS_BTN | CCF_HAT);
 		}
 

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1489,28 +1489,12 @@ void control_config_common_read_section(int s) {
 
 	} else {
 		// Add new preset, if it is unique
-		bool unique = true;
-		auto it = Control_config_presets.begin();
-		for (; it != Control_config_presets.end(); ++it) {
-			size_t i;
-			for (i = 0; i < it->bindings.size(); ++i) {
-				if (new_preset.bindings[i] != it->bindings[i]) {
-					// These two differ, check the next in the vector
-					break;
-				}
-			}
-
-			if (i == it->bindings.size()) {
-				// These two are equal
-				unique = false;
-				break;
-			}
-		}
+		bool unique = preset_is_unique(new_preset);
 
 		if (unique) {
 			Control_config_presets.push_back(new_preset);
 		} else if (!running_unittests) {
-			Warning(LOCATION, "Preset '%s' found in 'controlconfigdefaults.tbl' is a duplicate of existing preset '%s', ignoring\n", new_preset.name.c_str(), it->name.c_str());
+			Warning(LOCATION, "TBL => Preset '%s' found in 'controlconfigdefaults.tbl' is a duplicate of an existing preset, ignoring\n", new_preset.name.c_str());
 		}
 	}
 };
@@ -2400,11 +2384,11 @@ short CCB::get_btn(CID cid) const {
 	}
 }
 
-bool CCB::operator==(const CCB& A) {
+bool CCB::operator==(const CCB& A) const {
 	return (first == A.first) && (second == A.second);
 }
 
-bool CCB::operator!=(const CCB& A) {
+bool CCB::operator!=(const CCB& A) const {
 	return !this->operator==(A);
 }
 

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1240,6 +1240,7 @@ void stuff_CCF(char& flags, size_t item_id) {
 }
 
 // Legacy reading method for parsing keyboard and joystick/mouse bindings
+// Will overwrite/override the given preset for all options found within the .tbl section
 size_t read_bind_0(CC_preset &new_preset) {
 	SCP_string szTempBuffer;
 
@@ -1257,14 +1258,14 @@ size_t read_bind_0(CC_preset &new_preset) {
 	}
 
 	// Assign the various attributes to this control
-	int iTemp;
-	short key = 0;
 	auto& new_binding = new_preset.bindings[item_id];
+	int iTemp;
+	short key = new_binding.get_btn(CID_KEYBOARD);
 
 	// Key assignment and modifiers
 	if (optional_string("$Key Default:")) {
 		if (optional_string("NONE")) {
-			new_binding.take(CC_bind(CID_KEYBOARD, -1), -1);
+			key = -1;
 		} else {
 			stuff_string(szTempBuffer, F_NAME);
 			key = mKeyNameToVal[szTempBuffer];
@@ -1286,7 +1287,12 @@ size_t read_bind_0(CC_preset &new_preset) {
 		key |= (iTemp == 1) ? KEY_CTRLED : 0;
 	}
 
-	new_binding.take(CC_bind(CID_KEYBOARD, key), 0);
+	if (key > 0) {
+		new_binding.take(CC_bind(CID_KEYBOARD, key), 0);
+	} else {
+		new_binding.take(CC_bind(CID_KEYBOARD, static_cast<short>(-1)), -1);
+	}
+	
 
 	// Joy btn assignment
 	if (optional_string("$Joy Default:")) {
@@ -1298,7 +1304,7 @@ size_t read_bind_0(CC_preset &new_preset) {
 }
 
 // Reading method for parsing keyboard, mouse, and multi-joy bindings
-// TODO: override, or clean slate
+// Will override/overwrite the given preset for all options found within the .tbl section
 size_t read_bind_1(CC_preset &preset) {
 	CCB* item = nullptr;
 	SCP_string szTempBuffer;

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1356,7 +1356,13 @@ void control_config_common_read_tbl() {
 template<class FILETYPE>
 int control_config_common_write_tbl_segment(FILETYPE* cfile, int preset, int (* puts)(const char *, FILETYPE*) ) {
 
-	puts("#ControlConfigOverride\n", cfile);
+	if (preset == 0) {
+		puts("#ControlConfigOverride\n", cfile);
+
+	} else {
+		puts("#ControlConfigPreset", cfile);
+	}
+	
 	puts(("$Name: " + Control_config_presets[preset].name + "\n").c_str(), cfile);
 
 	// Write bindings for all controls

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1158,7 +1158,8 @@ size_t find_control_by_text(SCP_string& text) {
  *
  * @param[in] s Value of a call to optional_string_either(); 0 = "ControlConfigOverride" 1 = "ControlConfigPreset"
  *
- * @details ControlConfigPresets are read in the exact same manner as ControlConfigOverrides, however only the bindings are available for modification
+ * @details ControlConfigPresets are read in the exact same manner as ControlConfigOverrides, however only the bindings are available for modification.
+ *  There may be only one #Override section, since it is in charge of non-binding members of the Control_config items
  */
 void control_config_common_read_section(int s) {
 	CC_preset new_preset;
@@ -1182,6 +1183,7 @@ void control_config_common_read_section(int s) {
 	
 
 	// Assign name to the preset
+	// note: #Override section's name is ignored
 	if (optional_string("$Name:")) {
 		SCP_string name;
 		stuff_string_line(name);
@@ -1296,8 +1298,8 @@ void control_config_common_read_section(int s) {
 
 	required_string("#End");
 
-	if ((s == 0) && (new_preset.name == default_preset.name)) {
-		// If this is an override section, and the preset name is the same as the hardcoded defaults, override the defaults
+	if (s == 0) {
+		// If this is an override section, override the defaults
 		auto& new_bindings = new_preset.bindings;
 		std::copy(new_bindings.begin(), new_bindings.end(), default_bindings.begin());
 
@@ -1386,11 +1388,13 @@ int control_config_common_write_tbl_segment(FILETYPE* cfile, int preset, int (* 
 		puts(("    $Flags: " + ValToCCF(second.flags) + "\n").c_str(), cfile);
 		puts(("    $Input: " + ValToInput(second) + "\n").c_str(), cfile);
 
-		// Config menu options
-		puts(("  $Category: " + ValToCCTab(item.tab) + "\n").c_str(), cfile);
-		puts(("  $Text: " + item.text + "\n").c_str(), cfile);
-		puts(("  $Has XStr: " + std::to_string(item.indexXSTR) + "\n").c_str(), cfile);
-		puts(("  $Type: " + ValToCCType(item.type) + "\n").c_str(), cfile);
+		// Config menu options (default #Override Only)
+		if (preset == 0) {
+			puts(("  $Category: " + ValToCCTab(item.tab) + "\n").c_str(), cfile);
+			puts(("  $Text: " + item.text + "\n").c_str(), cfile);
+			puts(("  $Has XStr: " + std::to_string(item.indexXSTR) + "\n").c_str(), cfile);
+			puts(("  $Type: " + ValToCCType(item.type) + "\n").c_str(), cfile);
+		}
 	}
 
 	puts("#End\n", cfile);

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1324,14 +1324,16 @@ size_t read_bind_1(CC_preset &preset) {
 			item.first.cid = CIDToVal(szTempBuffer.c_str());
 		}
 		
-		if (required_string("$Flags:")) {
-			stuff_CCF(item.first.flags, item_id);
-		}
+		// These items are required if the controller is defined
+		if (item.first.cid != CID_NONE) {
+			if (required_string("$Flags:")) {
+				stuff_CCF(item.first.flags, item_id);
+			}
 
-		if (required_string("$Input:")) {
-			stuff_string(szTempBuffer, F_NAME);
-
-			item.first.btn = InputToVal(item.first.cid, szTempBuffer.c_str());
+			if (required_string("$Input:")) {
+				stuff_string(szTempBuffer, F_NAME);
+				item.first.btn = InputToVal(item.first.cid, szTempBuffer.c_str());
+			}
 		}
 
 		item.first.validate();
@@ -1341,20 +1343,22 @@ size_t read_bind_1(CC_preset &preset) {
 	if (optional_string("$Secondary:")) {
 		if (required_string("$Controller:")) {
 			stuff_string(szTempBuffer, F_NAME);
-			item.first.cid = CIDToVal(szTempBuffer.c_str());
+			item.second.cid = CIDToVal(szTempBuffer.c_str());
 		}
 
-		if (required_string("$Flags:")) {
-			stuff_CCF(item.first.flags, item_id);
+		// These items are required if the controller is defined
+		if (item.second.cid != CID_NONE) {
+			if (required_string("$Flags:")) {
+				stuff_CCF(item.second.flags, item_id);
+			}
+
+			if (required_string("$Input:")) {
+				stuff_string(szTempBuffer, F_NAME);
+				item.second.btn = InputToVal(item.second.cid, szTempBuffer.c_str());
+			}
 		}
 
-		if (required_string("$Input:")) {
-			stuff_string(szTempBuffer, F_NAME);
-
-			item.first.btn = InputToVal(item.first.cid, szTempBuffer.c_str());
-		}
-
-		item.first.validate();
+		item.second.validate();
 	}
 
 	return static_cast<size_t>(item_id);
@@ -1425,6 +1429,7 @@ void control_config_common_read_section(int s) {
 
 		default:
 			UNREACHABLE("[controlconfigdefaults.tbl] required_string_either passed something other than 0 or 1!");
+			item_id = Control_config.size();
 		}
 
 		if (item_id == Control_config.size()) {
@@ -1558,14 +1563,18 @@ int control_config_common_write_tbl_segment(FILETYPE* cfile, int preset, int (* 
 		// Primary binding
 		puts("  $Primary:\n", cfile);
 		puts(("    $Controller: " + ValToCID(first.cid) + "\n").c_str(), cfile);
-		puts(("    $Flags: " + ValToCCF(first.flags) + "\n").c_str(), cfile);
-		puts(("    $Input: " + ValToInput(first) + "\n").c_str(), cfile);
+		if (first.cid != CID_NONE) {
+			puts(("    $Flags: " + ValToCCF(first.flags) + "\n").c_str(), cfile);
+			puts(("    $Input: " + ValToInput(first) + "\n").c_str(), cfile);
+		}
 
 		// Secondary binding
 		puts("  $Secondary:\n", cfile);
 		puts(("    $Controller: " + ValToCID(second.cid) + "\n").c_str(), cfile);
-		puts(("    $Flags: " + ValToCCF(second.flags) + "\n").c_str(), cfile);
-		puts(("    $Input: " + ValToInput(second) + "\n").c_str(), cfile);
+		if (second.cid != CID_NONE) {
+			puts(("    $Flags: " + ValToCCF(second.flags) + "\n").c_str(), cfile);
+			puts(("    $Input: " + ValToInput(second) + "\n").c_str(), cfile);
+		}
 
 		// Config menu options (default #Override Only)
 		if (preset == 0) {
@@ -1643,15 +1652,15 @@ DCF(save_ccd, "Save the current Control Configuration Defaults to .tbl") {
 	}
 
 	if (!control_config_common_write_tbl(true, createAll)) {
-		dc_printf("Default bindings saved to controlconfigdefaults.tbl");
+		dc_printf("Default bindings saved to controlconfigdefaults.tbl\n");
 	} else {
-		dc_printf("Error: Unable to save Control Configuration Defaults.");
+		dc_printf("Error: Unable to save Control Configuration Defaults.\n");
 	}
 }
 
 DCF(load_ccd, "Reloads Control Configuration Defaults and Presets from .tbl") {
 	control_config_common_read_tbl();
-	dc_printf("Default bindings and presets loaded.");
+	dc_printf("Default bindings and presets loaded.\n");
 }
 
 /**

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1966,7 +1966,7 @@ SCP_string ValToCCTab(char tab) {
 
 SCP_string ValToCCType(CC_type type) {
 	auto it = std::find_if(mCCTypeNameToVal.cbegin(), mCCTypeNameToVal.cend(),
-						   [type](const std::pair<SCP_string, char>& pair) {return pair.second == type; });
+						   [type](const std::pair<SCP_string, CC_type>& pair) { return pair.second == type; });
 
 	if (it == mCCTypeNameToVal.cend()) {
 		// Shouldn't happen

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1492,14 +1492,20 @@ void control_config_common_read_section(int s) {
 		bool unique = true;
 		auto it = Control_config_presets.begin();
 		for (; it != Control_config_presets.end(); ++it) {
-			for (size_t i = 0; i < it->bindings.size(); ++i) {
-				if (new_preset.bindings[i] == it->bindings[i]) {
-					unique = false;
-					goto not_unique;
+			size_t i;
+			for (i = 0; i < it->bindings.size(); ++i) {
+				if (new_preset.bindings[i] != it->bindings[i]) {
+					// These two differ, check the next in the vector
+					break;
 				}
 			}
+
+			if (i == it->bindings.size()) {
+				// These two are equal
+				unique = false;
+				break;
+			}
 		}
-		not_unique:;
 
 		if (unique) {
 			Control_config_presets.push_back(new_preset);
@@ -1546,7 +1552,7 @@ int control_config_common_write_tbl_segment(FILETYPE* cfile, int preset, int (* 
 		puts("#ControlConfigOverride\n", cfile);
 
 	} else {
-		puts("#ControlConfigPreset", cfile);
+		puts("#ControlConfigPreset\n", cfile);
 	}
 	
 	puts(("$Name: " + Control_config_presets[preset].name + "\n").c_str(), cfile);

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -199,7 +199,7 @@ void control_config_common_init_bindings() {
 
 	(RADAR_RANGE_CYCLE,                            KEY_RAPOSTRO, -1, COMPUTER_TAB, 1, "Cycle Radar Range",                 CC_TYPE_TRIGGER)
 	(SQUADMSG_MENU,                                       KEY_C, -1, COMPUTER_TAB, 1, "Communications Menu",               CC_TYPE_TRIGGER)
-	(SHOW_GOALS,                                             -1, -1, NO_TAB,       1, "Show Objectives",                   CC_TYPE_TRIGGER)
+	(SHOW_GOALS,                                             -1, -1, NO_TAB,       1, "Show Objectives",                   CC_TYPE_TRIGGER, true)
 	(END_MISSION,                             KEY_ALTED | KEY_J, -1, COMPUTER_TAB, 1, "Enter Subspace (End Mission)",      CC_TYPE_TRIGGER)
 
 	(INCREASE_WEAPON,                                KEY_INSERT, -1, COMPUTER_TAB, 1, "Weapon Energy Increase",            CC_TYPE_TRIGGER)
@@ -219,7 +219,7 @@ void control_config_common_init_bindings() {
 	(XFER_LASER,                    KEY_SHIFTED | KEY_SCROLLOCK, -1, COMPUTER_TAB, 1, "Transfer Energy Shield->Laser",     CC_TYPE_TRIGGER)
 
 	// Navigation and Autopilot
-	(SHOW_NAVMAP,                                            -1, -1, NO_TAB,       1, "Show Nav Map",       CC_TYPE_TRIGGER)
+	(SHOW_NAVMAP,                                            -1, -1, NO_TAB,       1, "Show Nav Map",       CC_TYPE_TRIGGER, true)
 	(AUTO_PILOT_TOGGLE,                       KEY_ALTED | KEY_A, -1, COMPUTER_TAB, 0, "Toggle Auto Pilot",  CC_TYPE_TRIGGER, true)
 	(NAV_CYCLE,                               KEY_ALTED | KEY_N, -1, COMPUTER_TAB, 0, "Cycle Nav Points",   CC_TYPE_TRIGGER, true)
 

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1300,7 +1300,7 @@ size_t read_bind_0(CC_preset &new_preset) {
 // Reading method for parsing keyboard, mouse, and multi-joy bindings
 // TODO: override, or clean slate
 size_t read_bind_1(CC_preset &preset) {
-	auto &item = preset.bindings[0];
+	CCB* item = nullptr;
 	SCP_string szTempBuffer;
 	int item_id = 0;
 
@@ -1309,7 +1309,7 @@ size_t read_bind_1(CC_preset &preset) {
 	item_id = ActionToVal(szTempBuffer.c_str());
 
 	if (item_id >= 0) {
-		item = preset.bindings[item_id];
+		item = &preset.bindings[item_id];
 
 	} else {
 		// Control wasn't found
@@ -1321,44 +1321,44 @@ size_t read_bind_1(CC_preset &preset) {
 	if (optional_string("$Primary:")) {
 		if (required_string("$Controller:")) {
 			stuff_string(szTempBuffer, F_NAME);
-			item.first.cid = CIDToVal(szTempBuffer.c_str());
+			item->first.cid = CIDToVal(szTempBuffer.c_str());
 		}
 		
 		// These items are required if the controller is defined
-		if (item.first.cid != CID_NONE) {
+		if (item->first.cid != CID_NONE) {
 			if (required_string("$Flags:")) {
-				stuff_CCF(item.first.flags, item_id);
+				stuff_CCF(item->first.flags, item_id);
 			}
 
 			if (required_string("$Input:")) {
 				stuff_string(szTempBuffer, F_NAME);
-				item.first.btn = InputToVal(item.first.cid, szTempBuffer.c_str());
+				item->first.btn = InputToVal(item->first.cid, szTempBuffer.c_str());
 			}
 		}
 
-		item.first.validate();
+		item->first.validate();
 	}
 
 	// Second verse, same as the first
 	if (optional_string("$Secondary:")) {
 		if (required_string("$Controller:")) {
 			stuff_string(szTempBuffer, F_NAME);
-			item.second.cid = CIDToVal(szTempBuffer.c_str());
+			item->second.cid = CIDToVal(szTempBuffer.c_str());
 		}
 
 		// These items are required if the controller is defined
-		if (item.second.cid != CID_NONE) {
+		if (item->second.cid != CID_NONE) {
 			if (required_string("$Flags:")) {
-				stuff_CCF(item.second.flags, item_id);
+				stuff_CCF(item->second.flags, item_id);
 			}
 
 			if (required_string("$Input:")) {
 				stuff_string(szTempBuffer, F_NAME);
-				item.second.btn = InputToVal(item.second.cid, szTempBuffer.c_str());
+				item->second.btn = InputToVal(item->second.cid, szTempBuffer.c_str());
 			}
 		}
 
-		item.second.validate();
+		item->second.validate();
 	}
 
 	return static_cast<size_t>(item_id);

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1504,7 +1504,7 @@ void control_config_common_read_section(int s) {
 		if (unique) {
 			Control_config_presets.push_back(new_preset);
 		} else if (!running_unittests) {
-			Warning(LOCATION, "Preset '%s' found in 'controlconfigdefaults.tbl' is a duplicate of existing preset '%s', ignoring", new_preset.name.c_str(), it->name.c_str());
+			Warning(LOCATION, "Preset '%s' found in 'controlconfigdefaults.tbl' is a duplicate of existing preset '%s', ignoring\n", new_preset.name.c_str(), it->name.c_str());
 		}
 	}
 };
@@ -1680,7 +1680,7 @@ void control_config_common_load_overrides()
 	}
 	catch (const parse::ParseException& e)
 	{
-		mprintf(("TABLES: Unable to parse 'controlconfigdefaults.tbl'!  Error message = %s.\n", e.what()));
+		mprintf(("TABLES: Unable to parse 'controlconfigdefaults.tbl'!  Error message = '%s'.\n", e.what()));
 		return;
 	}
 }
@@ -2555,7 +2555,7 @@ CCI_builder& CCI_builder::operator()(IoActionId action_id, short primary, short 
 	item.type = type;
 
 	if (tab == NO_TAB) {
-		mprintf(("Control item defined without a valid tab. Disabling: %s", item.text.c_str()));
+		mprintf(("CCI_builder::operator(): Control item defined without a valid tab. Disabling: '%s'\n", item.text.c_str()));
 	}
 
 	// Enable if it has a valid tab and if caller wants it enabled

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1526,7 +1526,7 @@ void control_config_common_read_section(int s) {
 	// Error case of preset sections named "default" is handled in the beginning of this function
 	if ((s == 0) && (new_preset.name == "default")) {
 		Control_config_presets[0] = new_preset;
-		mprintf(("[controlconfigdefaults.tbl] Overrode default preset.", new_preset.name.c_str()));
+		mprintf(("[controlconfigdefaults.tbl] Overrode default preset."));
 	}
 
 	auto duplicate = preset_find_duplicate(new_preset);

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1189,7 +1189,7 @@ void stuff_CCF(char& flags, size_t item_id) {
 	case CC_TYPE_CONTINUOUS:
 		// Digital control. May not have:
 		if ((flags & (CCF_AXIS | CCF_BALL)) != 0) {
-			error_display(0, "Illegal analog flags passed to digital config item %i, ignoring...", item_id);
+			error_display(0, "Illegal analog flags passed to digital config item %i, ignoring...", static_cast<int>(item_id));
 			flags &= ~(CCF_AXIS | CCF_BALL);
 		}
 		break;
@@ -1197,12 +1197,12 @@ void stuff_CCF(char& flags, size_t item_id) {
 	case CC_TYPE_AXIS_ABS:
 		// Absolute Analog control. Must not have:
 		if ((flags & (CCF_AXIS_BTN | CCF_HAT)) != 0) {
-			error_display(0, "Illegal digital flags passed to analog config item %i, ignoring...", item_id);
+			error_display(0, "Illegal digital flags passed to analog config item %i, ignoring...", static_cast<int>(item_id));
 			flags &= ~(CCF_AXIS_BTN | CCF_HAT);
 		}
 
 		if ((flags & CCF_RELATIVE) != 0) {
-			error_display(0, "Illegal RELATIVE flag passed to absolute analog config item %i, ignoring...", item_id);
+			error_display(0, "Illegal RELATIVE flag passed to absolute analog config item %i, ignoring...", static_cast<int>(item_id));
 			flags &= ~CCF_RELATIVE;
 		}
 
@@ -1216,7 +1216,7 @@ void stuff_CCF(char& flags, size_t item_id) {
 	case CC_TYPE_AXIS_REL:
 		// Relative Analog control. Must not have:
 		if ((flags & (CCF_AXIS_BTN | CCF_HAT)) != 0) {
-			error_display(0, "Illegal digital flags passed to analog config item %i, ignoring...", item_id);
+			error_display(0, "Illegal digital flags passed to analog config item %i, ignoring...", static_cast<int>(item_id));
 			flags &= ~(CCF_AXIS_BTN | CCF_HAT);
 		}
 
@@ -1227,7 +1227,7 @@ void stuff_CCF(char& flags, size_t item_id) {
 		}
 
 		if ((flags & CCF_RELATIVE) == 0) {
-			error_display(0, "Missing RELATIVE flag for relative analog config item %i, adding...", item_id);
+			error_display(0, "Missing RELATIVE flag for relative analog config item %i, adding...", static_cast<int>(item_id));
 			flags |= CCF_RELATIVE;
 		}
 		break;
@@ -1259,7 +1259,6 @@ size_t read_bind_0(CC_preset &new_preset) {
 	// Assign the various attributes to this control
 	int iTemp;
 	short key = 0;
-	auto  item = &Control_config[item_id];
 	auto& new_binding = new_preset.bindings[item_id];
 
 	// Key assignment and modifiers
@@ -1408,7 +1407,6 @@ void control_config_common_read_section(int s) {
 
 	// Read the section
 	while (required_string_one_of(3, "#End", "$Bind Name:", "$Bind")) {
-		int version = required_string_either("$Bind Name:", "$Bind:");
 		size_t item_id;
 
 		switch (required_string_either("$Bind Name:", "$Bind:")) {

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1396,7 +1396,7 @@ void control_config_common_read_section(int s) {
 	// note: #Override section's name is ignored
 	if (optional_string("$Name:")) {
 		SCP_string name;
-		stuff_string_line(name);
+		stuff_string(name, F_NAME);
 		new_preset.name = name;
 
 		auto it = std::find_if(Control_config_presets.begin(), Control_config_presets.end(), [&name](CC_preset& S) {return S.name == name;});

--- a/code/controlconfig/presets.cpp
+++ b/code/controlconfig/presets.cpp
@@ -122,22 +122,12 @@ void load_preset_files() {
 		handler->endArrayRead(); // Actions
 
 		// Done with the file
-		bool unique = false;
-		auto it = Control_config_presets.begin();
-		for (; it != Control_config_presets.end(); ++it) {
-			for (size_t i = 0; i < it->bindings.size(); ++i) {
-				if (preset.bindings[i] != it->bindings[i]) {
-					unique = true;
-					goto is_unique;
-				}
-			}
-		}
-		is_unique:;
+		bool unique = preset_is_unique(preset);
 
 		if (unique) {
 			Control_config_presets.push_back(preset);
 		} else {
-			Warning(LOCATION, "Preset '%s' is a duplicate of '%s', ignoring", preset.name.c_str(), it->name.c_str());
+			Warning(LOCATION, "PST => Preset '%s' is a duplicate of an existing preset, ignoring", preset.name.c_str());
 		}
 		
 	}
@@ -209,6 +199,26 @@ bool save_preset_file(CC_preset preset, bool overwrite) {
 	handler->endArrayWrite(); // Actions
 
 	handler->flush();
+
+	return true;
+}
+
+bool preset_is_unique(const CC_preset& new_preset) {
+	auto it = Control_config_presets.begin();
+	for (; it != Control_config_presets.end(); ++it) {
+		size_t i;
+		for (i = 0; i < it->bindings.size(); ++i) {
+			if (new_preset.bindings[i] != it->bindings[i]) {
+				// These two differ, check the next in the vector
+				break;
+			}
+		}
+
+		if (i == it->bindings.size()) {
+			// These two are equal
+			return false;
+		}
+	}
 
 	return true;
 }

--- a/code/controlconfig/presets.cpp
+++ b/code/controlconfig/presets.cpp
@@ -47,7 +47,7 @@ void load_preset_files() {
 						   CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 		if (!fp) {
-			mprintf(("PLR => Unable to open '%s' for loading!\n", file.c_str()));
+			mprintf(("PST => Unable to open '%s' for loading!\n", file.c_str()));
 			// try next
 			continue;
 		}
@@ -55,7 +55,7 @@ void load_preset_files() {
 		try {
 			handler.reset(new PresetFileHandler(fp, true));
 		} catch (const std::exception& e) {
-			mprintf(("PLR => Failed to open JSON: `%s`\n", e.what()));
+			mprintf(("PST => Failed to open JSON: `%s`\n", e.what()));
 			continue;
 		}
 

--- a/code/controlconfig/presets.cpp
+++ b/code/controlconfig/presets.cpp
@@ -128,7 +128,7 @@ void load_preset_files() {
 		if (it == Control_config_presets.end()) {
 			Control_config_presets.push_back(preset);
 
-		} if ((it->name != preset.name) || (it->type != Preset_t::pst)) {
+		} else if ((it->name != preset.name) || (it->type != Preset_t::pst)) {
 			// Complain and ignore if the preset names or the type differs
 			Warning(LOCATION, "PST => Preset '%s' is a duplicate of an existing preset, ignoring", preset.name.c_str());
 		

--- a/code/controlconfig/presets.h
+++ b/code/controlconfig/presets.h
@@ -215,8 +215,8 @@ bool save_preset_file(CC_preset preset, bool overwrite);
 void load_preset_files();
 
 /**
- * @brief Checks if the given preset is unique among the currently loaded presets
- * @returns true    if unique, or
- * @returns false   otherwise
+ * @brief Checks if the given preset is a duplicate within Control_config_presets vector
+ * @returns tterator to the duplicate if found, or
+ * @returns iterator to Control_config_presets.end() otherwise
  */
-bool preset_is_unique(const CC_preset& new_preset);
+SCP_vector<CC_preset>::iterator preset_find_duplicate(const CC_preset& new_preset);

--- a/code/controlconfig/presets.h
+++ b/code/controlconfig/presets.h
@@ -213,3 +213,10 @@ bool save_preset_file(CC_preset preset, bool overwrite);
  * a preset is a duplicate of another preset, it is ignored, and the player is warned of it
  */
 void load_preset_files();
+
+/**
+ * @brief Checks if the given preset is unique among the currently loaded presets
+ * @returns true    if unique, or
+ * @returns false   otherwise
+ */
+bool preset_is_unique(const CC_preset& new_preset);

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1255,7 +1255,13 @@ void pilotfile::csg_write_controls()
 {
 	auto it = control_config_get_current_preset();
 
-	cfwrite_string(it->name.c_str(), cfp);
+	if (it != Control_config_presets.end()) {
+		cfwrite_string(it->name.c_str(), cfp);
+
+	} else {
+		Warning(LOCATION, "CSG => Tried to save to campaign file with invalid preset! Using default preset.");
+		cfwrite_string(Control_config_presets[0].name.c_str(), cfp);
+	}
 }
 
 void pilotfile::csg_read_cutscenes() {

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -622,7 +622,14 @@ void pilotfile::plr_write_controls()
 	handler->startSectionWrite(Section::Controls);
 	
 	auto it = control_config_get_current_preset();
-	handler->writeString("preset", it->name.c_str());
+
+	if (it != Control_config_presets.end()) {
+		handler->writeString("preset", it->name.c_str());
+
+	} else {
+		Warning(LOCATION, "PLR => Tried to save pilotfile with an invalid preset! Using default preset.");
+		handler->writeString("preset", Control_config_presets[0].name.c_str());
+	}
 
 	// For forward compatibility with old versions of FSO, we must still save the preset to the best of our ability.
 	// This is required because the plr_read will trigger an error and halt FSO execution.


### PR DESCRIPTION
Updates the controlconfigdefaults.tbl to use Primary/Secondary binding scheme

- [x] save_ccd should use the new format
- [x] cmdline flag should use the new format
- [x] load_ccd should be able to load new format
- [x] load_ccd should be able to load old format
- [x] game should be able to load new format
- [x] game should be able to load old format
- [x] Should get warnings about unknown IoActionId's
- [x] should get warnings about illegal CCF's.
- [x] Override sections may overwrite the `default` preset if named as such
- [x] Override sections may rename the default preset if they end up being a duplicate
- [x] Override sections create new presets, using the `default` as a baseline