### PR TITLE
Controls6 format fix for localized keynames

### DIFF
--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -658,7 +658,7 @@ const char *textify_scancode(int code)
 	}
 
 	SCP_string name;
-	unicode::convert_encoding(name, SDL_GetKeyName(SDL_GetKeyFromScancode(fs2_to_sdl(keycode))), unicode::Encoding_utf8);
+	unicode::convert_encoding(name, SDL_GetKeyName(SDL_GetKeyFromScancode(fs2_to_sdl(keycode))), unicode::Encoding::Encoding_utf8);
 	strcat_s(text, name.c_str());
 	return text;
 }

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -657,7 +657,7 @@ const char *textify_scancode(int code)
 		}
 	}
 
-	strcat_s(text, SDL_GetKeyName(SDL_GetKeyFromScancode(fs2_to_sdl(keycode))));
+	strcat_s(text, utf8_to_current(SDL_GetKeyName(SDL_GetKeyFromScancode(fs2_to_sdl(keycode)))).c_str());
 	return text;
 }
 

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -658,7 +658,7 @@ const char *textify_scancode(int code)
 	}
 
 	SCP_string name;
-	convert_encoding(name, SDL_GetKeyName(SDL_GetKeyFromScancode(fs2_to_sdl(keycode))), ENCODING_UTF8);
+	unicode::convert_encoding(name, SDL_GetKeyName(SDL_GetKeyFromScancode(fs2_to_sdl(keycode))), unicode::Encoding_utf8);
 	strcat_s(text, name.c_str());
 	return text;
 }

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -657,7 +657,9 @@ const char *textify_scancode(int code)
 		}
 	}
 
-	strcat_s(text, utf8_to_current(SDL_GetKeyName(SDL_GetKeyFromScancode(fs2_to_sdl(keycode)))).c_str());
+	SCP_string name;
+	convert_encoding(name, SDL_GetKeyName(SDL_GetKeyFromScancode(fs2_to_sdl(keycode))), ENCODING_UTF8);
+	strcat_s(text, name.c_str());
 	return text;
 }
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2285,41 +2285,7 @@ void coerce_to_utf8(SCP_string &buffer, const char *str)
 	// we can convert it
 	if (isLatin1)
 	{
-		size_t newlen = len;
-		std::unique_ptr<char[]> newstr(new char[newlen]);
-
-		do {
-			auto in_str = str;
-			auto in_size = len;
-			auto out_str = newstr.get();
-			auto out_size = newlen;
-
-			auto iconv = SDL_iconv_open("UTF-8", "ISO-8859-1");
-			auto err = SDL_iconv(iconv, &in_str, &in_size, &out_str, &out_size);
-			SDL_iconv_close(iconv);
-
-			// SDL returns the number of processed character on success;
-			// error codes are (size_t)-1 through -4
-			if (err < (size_t)-100)
-			{
-				// successful re-encoding
-				buffer.assign(newstr.get(), newlen - out_size);
-				mprintf(("Re-encoding non-UTF-8 string '%s' to '%s'!\n", str, buffer.c_str()));
-				return;
-			}
-			else if (err == SDL_ICONV_E2BIG)
-			{
-				// buffer is not big enough, try again with a bigger buffer. Use a rather conservative size
-				// increment since the additional size required is probably pretty small
-				newlen += 10;
-				newstr.reset(new char[newlen]);
-			}
-			else
-			{
-				// re-encoding failed, so use truncation
-				break;
-			}
-		} while (true);
+		convert_encoding(buffer, str, ENCODING_ISO8859_1, ENCODING_UTF8);
 	}
 
 	// unknown encoding, so just truncate
@@ -2327,95 +2293,41 @@ void coerce_to_utf8(SCP_string &buffer, const char *str)
 	Warning(LOCATION, "Truncating non-UTF-8 string '%s' to '%s'!\n", str, buffer.c_str());
 }
 
-//Converts a string in ISO 8859-1 to the currently used encoding
-//Only legal for strings with correct ISO 8859-1 encoding
-SCP_string iso8859_1_to_current(const char* str)
-{
-	SCP_string buffer;
-	//We are not in unicode mode, so just return as is, the string is correct
-	if (!Unicode_text_mode) {
-		buffer.assign(str);
-		return buffer;
+const char* const get_encoding_string(int encoding) {
+	switch (encoding) {
+	case ENCODING_ISO8859_1:
+		return "ISO-8859-1";
+	case ENCODING_UTF8:
+		return "UTF-8";
+	case ENCODING_CURRENT:
+	default:
+		UNREACHABLE("Unknown encoding type was passed: %d\n", encoding);
+		return "";
 	}
-
-	//If not, convert to utf-8
-	auto len = strlen(str);
-
-	// Validate the UTF-8 encoding
-	bool valid = true;
-
-	for (size_t i = 0; i < len; i++) {
-		if (str[i] > 0x79 || str[i] < 0) {
-			valid = false;
-			break;
-		}
-	}
-
-	if (valid)
-	{
-		// turns out this is valid UTF-8
-		buffer.assign(str);
-		return buffer;
-	}
-
-	//Skip checks. This function is only allowed for known iso8859-1 encoded strings
-
-	size_t newlen = len;
-	std::unique_ptr<char[]> newstr(new char[newlen]);
-
-	do {
-		auto in_str = str;
-		auto in_size = len;
-		auto out_str = newstr.get();
-		auto out_size = newlen;
-
-		auto iconv = SDL_iconv_open("UTF-8", "ISO-8859-1");
-		auto err = SDL_iconv(iconv, &in_str, &in_size, &out_str, &out_size);
-		SDL_iconv_close(iconv);
-
-		// SDL returns the number of processed character on success;
-		// error codes are (size_t)-1 through -4
-		if (err < (size_t)-100)
-		{
-			// successful re-encoding
-			buffer.assign(newstr.get(), newlen - out_size);
-			return buffer;
-		}
-		else if (err == SDL_ICONV_E2BIG)
-		{
-			// buffer is not big enough, try again with a bigger buffer. Use a rather conservative size
-			// increment since the additional size required is probably pretty small
-			newlen += 10;
-			newstr.reset(new char[newlen]);
-		}
-		else
-		{
-			break;
-		}
-	} while (true);
-
-	return "";
 }
 
-//Converts a string in UTF-8 to the currently used encoding
-//Only legal for strings with correct UTF-8 encoding
-SCP_string utf8_to_current(const char* str)
-{
-	SCP_string buffer;
-	//We are in unicode mode, so just return as is, the string is correct
-	if (Unicode_text_mode) {
-		buffer.assign(str);
-		return buffer;
+void convert_encoding(SCP_string& buffer, const char* src, int encoding_src, int encoding_dest) {
+
+	if (encoding_src == ENCODING_CURRENT)
+		encoding_src = Unicode_text_mode ? ENCODING_UTF8 : ENCODING_ISO8859_1;
+
+	if (encoding_dest == ENCODING_CURRENT)
+		encoding_dest = Unicode_text_mode ? ENCODING_UTF8 : ENCODING_ISO8859_1;
+
+	//We are already in the correct encoding, the string is correct
+	if (encoding_src == encoding_dest) {
+		buffer.assign(src);
+		return;
 	}
 
-	//If not, convert to iso8859-1
-	auto len = strlen(str);
+	//If not, convert
+	auto len = strlen(src);
 
-	// Validate the UTF-8 encoding
+	// Validate if no change needs to be done
 	bool valid = true;
 
 	for (size_t i = 0; i < len; i++) {
-		if (str[i] > 0x79 || str[i] < 0) {
+		if (src[i] > 0x79 || src[i] < 0) {
 			valid = false;
 			break;
 		}
@@ -2423,23 +2335,23 @@ SCP_string utf8_to_current(const char* str)
 
 	if (valid)
 	{
-		// turns out this is valid ISO8859-1
-		buffer.assign(str);
-		return buffer;
+		// turns out this is valid anyways
+		buffer.assign(src);
+		return;
 	}
-
-	//Skip checks. This function is only allowed for known utf-8 encoded strings
 
 	size_t newlen = len;
 	std::unique_ptr<char[]> newstr(new char[newlen]);
 
 	do {
-		auto in_str = str;
+		auto in_str = src;
 		auto in_size = len;
 		auto out_str = newstr.get();
 		auto out_size = newlen;
 
-		auto iconv = SDL_iconv_open("ISO-8859-1", "UTF-8");
+
+
+		auto iconv = SDL_iconv_open(get_encoding_string(encoding_dest), get_encoding_string(encoding_src));
 		auto err = SDL_iconv(iconv, &in_str, &in_size, &out_str, &out_size);
 		SDL_iconv_close(iconv);
 
@@ -2449,7 +2361,7 @@ SCP_string utf8_to_current(const char* str)
 		{
 			// successful re-encoding
 			buffer.assign(newstr.get(), newlen - out_size);
-			return buffer;
+			return;
 		}
 		else if (err == SDL_ICONV_E2BIG)
 		{
@@ -2463,8 +2375,6 @@ SCP_string utf8_to_current(const char* str)
 			break;
 		}
 	} while (true);
-
-	return "";
 }
 
 // Goober5000

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2285,7 +2285,7 @@ void coerce_to_utf8(SCP_string &buffer, const char *str)
 	// we can convert it
 	if (isLatin1)
 	{
-		unicode::convert_encoding(buffer, str, unicode::Encoding_iso8859_1, unicode::Encoding_utf8);
+		unicode::convert_encoding(buffer, str, unicode::Encoding::Encoding_iso8859_1, unicode::Encoding::Encoding_utf8);
 	}
 
 	// unknown encoding, so just truncate

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2293,7 +2293,7 @@ void coerce_to_utf8(SCP_string &buffer, const char *str)
 	Warning(LOCATION, "Truncating non-UTF-8 string '%s' to '%s'!\n", str, buffer.c_str());
 }
 
-const char* const get_encoding_string(int encoding) {
+const char* get_encoding_string(int encoding) {
 	switch (encoding) {
 	case ENCODING_ISO8859_1:
 		return "ISO-8859-1";

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -66,6 +66,10 @@ extern int Token_found_flag;
 #define SEXP_SAVE_MODE				1
 #define SEXP_ERROR_CHECK_MODE		2
 
+#define ENCODING_CURRENT	0
+#define ENCODING_UTF8		1
+#define ENCODING_ISO8859_1	2
+
 // Goober5000 - this seems to be a pretty universal function
 extern bool end_string_at_first_hash_symbol(char *src);
 extern bool end_string_at_first_hash_symbol(SCP_string &src);
@@ -264,8 +268,8 @@ extern void read_file_text_from_default(const default_file& file, char *processe
 extern void read_raw_file_text(const char *filename, int mode = CF_TYPE_ANY, char *raw_text = NULL);
 extern void process_raw_file_text(char *processed_text = NULL, char *raw_text = NULL);
 extern void coerce_to_utf8(SCP_string &buffer, const char *src);
-extern SCP_string iso8859_1_to_current(const char* src);
-extern SCP_string utf8_to_current(const char* src);
+extern const char* const get_encoding_string(int encoding);
+extern void convert_encoding(SCP_string& buffer, const char* src, int encoding_src, int encoding_dest = ENCODING_CURRENT);
 extern void debug_show_mission_text();
 extern void convert_sexp_to_string(SCP_string &dest, int cur_node, int mode);
 extern size_t maybe_convert_foreign_characters(const char *in, char *out, bool add_null = true);

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -264,6 +264,8 @@ extern void read_file_text_from_default(const default_file& file, char *processe
 extern void read_raw_file_text(const char *filename, int mode = CF_TYPE_ANY, char *raw_text = NULL);
 extern void process_raw_file_text(char *processed_text = NULL, char *raw_text = NULL);
 extern void coerce_to_utf8(SCP_string &buffer, const char *src);
+extern SCP_string iso8859_1_to_current(const char* src);
+extern SCP_string utf8_to_current(const char* src);
 extern void debug_show_mission_text();
 extern void convert_sexp_to_string(SCP_string &dest, int cur_node, int mode);
 extern size_t maybe_convert_foreign_characters(const char *in, char *out, bool add_null = true);

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -66,10 +66,6 @@ extern int Token_found_flag;
 #define SEXP_SAVE_MODE				1
 #define SEXP_ERROR_CHECK_MODE		2
 
-#define ENCODING_CURRENT	0
-#define ENCODING_UTF8		1
-#define ENCODING_ISO8859_1	2
-
 // Goober5000 - this seems to be a pretty universal function
 extern bool end_string_at_first_hash_symbol(char *src);
 extern bool end_string_at_first_hash_symbol(SCP_string &src);
@@ -268,8 +264,6 @@ extern void read_file_text_from_default(const default_file& file, char *processe
 extern void read_raw_file_text(const char *filename, int mode = CF_TYPE_ANY, char *raw_text = NULL);
 extern void process_raw_file_text(char *processed_text = NULL, char *raw_text = NULL);
 extern void coerce_to_utf8(SCP_string &buffer, const char *src);
-extern const char* get_encoding_string(int encoding);
-extern void convert_encoding(SCP_string& buffer, const char* src, int encoding_src, int encoding_dest = ENCODING_CURRENT);
 extern void debug_show_mission_text();
 extern void convert_sexp_to_string(SCP_string &dest, int cur_node, int mode);
 extern size_t maybe_convert_foreign_characters(const char *in, char *out, bool add_null = true);

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -268,7 +268,7 @@ extern void read_file_text_from_default(const default_file& file, char *processe
 extern void read_raw_file_text(const char *filename, int mode = CF_TYPE_ANY, char *raw_text = NULL);
 extern void process_raw_file_text(char *processed_text = NULL, char *raw_text = NULL);
 extern void coerce_to_utf8(SCP_string &buffer, const char *src);
-extern const char* const get_encoding_string(int encoding);
+extern const char* get_encoding_string(int encoding);
 extern void convert_encoding(SCP_string& buffer, const char* src, int encoding_src, int encoding_dest = ENCODING_CURRENT);
 extern void debug_show_mission_text();
 extern void convert_sexp_to_string(SCP_string &dest, int cur_node, int mode);

--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -156,4 +156,87 @@ size_t encoded_size(codepoint_t cp) {
 		return 1;
 	}
 }
+
+
+const char* get_encoding_string(Encoding encoding) {
+	switch (encoding) {
+	case Encoding_iso8859_1:
+		return "ISO-8859-1";
+	case Encoding_utf8:
+		return "UTF-8";
+	case Encoding_current:
+	default:
+		UNREACHABLE("Unknown encoding type was passed: %d\n", encoding);
+		return "";
+	}
+}
+
+void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest) {
+
+	if (encoding_src == Encoding_current)
+		encoding_src = Unicode_text_mode ? Encoding_utf8 : Encoding_iso8859_1;
+
+	if (encoding_dest == Encoding_current)
+		encoding_dest = Unicode_text_mode ? Encoding_utf8 : Encoding_iso8859_1;
+
+	//We are already in the correct encoding, the string is correct
+	if (encoding_src == encoding_dest) {
+		buffer.assign(src);
+		return;
+	}
+
+	//If not, convert
+	auto len = strlen(src);
+
+	// Validate if no change needs to be done
+	bool valid = true;
+
+	for (size_t i = 0; i < len; i++) {
+		if (src[i] > 0x79 || src[i] < 0) {
+			valid = false;
+			break;
+		}
+	}
+
+	if (valid)
+	{
+		// turns out this is valid anyways
+		buffer.assign(src);
+		return;
+	}
+
+	size_t newlen = len;
+	std::unique_ptr<char[]> newstr(new char[newlen]);
+
+	do {
+		auto in_str = src;
+		auto in_size = len;
+		auto out_str = newstr.get();
+		auto out_size = newlen;
+
+		auto iconv = SDL_iconv_open(get_encoding_string(encoding_dest), get_encoding_string(encoding_src));
+		auto err = SDL_iconv(iconv, &in_str, &in_size, &out_str, &out_size);
+		SDL_iconv_close(iconv);
+
+		// SDL returns the number of processed character on success;
+		// error codes are (size_t)-1 through -4
+		if (err < (size_t)-100)
+		{
+			// successful re-encoding
+			buffer.assign(newstr.get(), newlen - out_size);
+			return;
+		}
+		else if (err == SDL_ICONV_E2BIG)
+		{
+			// buffer is not big enough, try again with a bigger buffer. Use a rather conservative size
+			// increment since the additional size required is probably pretty small
+			newlen += 10;
+			newstr.reset(new char[newlen]);
+		}
+		else
+		{
+			break;
+		}
+	} while (true);
+}
 }

--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -160,11 +160,11 @@ size_t encoded_size(codepoint_t cp) {
 
 const char* get_encoding_string(Encoding encoding) {
 	switch (encoding) {
-	case Encoding_iso8859_1:
+	case Encoding::Encoding_iso8859_1:
 		return "ISO-8859-1";
-	case Encoding_utf8:
+	case Encoding::Encoding_utf8:
 		return "UTF-8";
-	case Encoding_current:
+	case Encoding::Encoding_current:
 	default:
 		UNREACHABLE("Unknown encoding type was passed: %d\n", encoding);
 		return "";
@@ -173,11 +173,11 @@ const char* get_encoding_string(Encoding encoding) {
 
 void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest) {
 
-	if (encoding_src == Encoding_current)
-		encoding_src = Unicode_text_mode ? Encoding_utf8 : Encoding_iso8859_1;
+	if (encoding_src == Encoding::Encoding_current)
+		encoding_src = Unicode_text_mode ? Encoding::Encoding_utf8 : Encoding::Encoding_iso8859_1;
 
-	if (encoding_dest == Encoding_current)
-		encoding_dest = Unicode_text_mode ? Encoding_utf8 : Encoding_iso8859_1;
+	if (encoding_dest == Encoding::Encoding_current)
+		encoding_dest = Unicode_text_mode ? Encoding::Encoding_utf8 : Encoding::Encoding_iso8859_1;
 
 	//We are already in the correct encoding, the string is correct
 	if (encoding_src == encoding_dest) {

--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -166,7 +166,7 @@ const char* get_encoding_string(Encoding encoding) {
 		return "UTF-8";
 	case Encoding::Encoding_current:
 	default:
-		UNREACHABLE("Unknown encoding type was passed: %d\n", encoding);
+		UNREACHABLE("Unknown encoding type was passed.\n");
 		return "";
 	}
 }

--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -157,6 +157,14 @@ size_t encoded_size(codepoint_t cp) {
 	}
 }
 
+bool string_is_ascii_only(const char* str, size_t len) {
+	for (size_t i = 0; i < len; i++) {
+		if (str[i] > 0x79 || str[i] < 0)
+			return false;
+	}
+
+	return true;
+}
 
 const char* get_encoding_string(Encoding encoding) {
 	switch (encoding) {
@@ -189,16 +197,7 @@ void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src
 	auto len = strlen(src);
 
 	// Validate if no change needs to be done
-	bool valid = true;
-
-	for (size_t i = 0; i < len; i++) {
-		if (src[i] > 0x79 || src[i] < 0) {
-			valid = false;
-			break;
-		}
-	}
-
-	if (valid)
+	if (string_is_ascii_only(src, len))
 	{
 		// turns out this is valid anyways
 		buffer.assign(src);

--- a/code/utils/unicode.h
+++ b/code/utils/unicode.h
@@ -165,6 +165,7 @@ void advance(octet_iterator& start, size_t n, octet_iterator end) {
 
 enum class Encoding { Encoding_current, Encoding_utf8, Encoding_iso8859_1 };
 
+bool string_is_ascii_only(const char* str, size_t len);
 const char* get_encoding_string(Encoding encoding);
 void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest = Encoding::Encoding_current);
 }

--- a/code/utils/unicode.h
+++ b/code/utils/unicode.h
@@ -163,4 +163,8 @@ void advance(octet_iterator& start, size_t n, octet_iterator end) {
 	}
 }
 
+enum Encoding { Encoding_current, Encoding_utf8, Encoding_iso8859_1	};
+
+const char* get_encoding_string(Encoding encoding);
+void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest = Encoding_current);
 }

--- a/code/utils/unicode.h
+++ b/code/utils/unicode.h
@@ -163,8 +163,8 @@ void advance(octet_iterator& start, size_t n, octet_iterator end) {
 	}
 }
 
-enum Encoding { Encoding_current, Encoding_utf8, Encoding_iso8859_1	};
+enum class Encoding { Encoding_current, Encoding_utf8, Encoding_iso8859_1 };
 
 const char* get_encoding_string(Encoding encoding);
-void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest = Encoding_current);
+void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest = Encoding::Encoding_current);
 }


### PR DESCRIPTION
Add conversion helpers is the same commit as used in PR scp-fs2open/fs2open.github.com#3263